### PR TITLE
Revert entrypoint changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM alpine:latest
+FROM alpine:3.18
 
-RUN apk add --no-cache curl jq
+RUN apk add --no-cache curl jq \
+    && adduser -D -u 1000 actionuser
 
 COPY entrypoint.sh /entrypoint.sh
+
+USER actionuser
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- revert entrypoint script to previous behavior
- keep Dockerfile pinned to Alpine 3.18 with non-root user

## Testing
- `bash -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_686332b7139c832588a913674d3984cf